### PR TITLE
[programmers-lv3] 연속 펄스 부분 수열의 합

### DIFF
--- a/java-programmers/src/dp/Programmers_lv3_연속_펄스_부분_수열의_합.java
+++ b/java-programmers/src/dp/Programmers_lv3_연속_펄스_부분_수열의_합.java
@@ -1,0 +1,26 @@
+package src.dp;
+
+public class Programmers_lv3_연속_펄스_부분_수열의_합 {
+    public long solution(int[] sequence) {
+        long answer = -100001;
+        int N = sequence.length;
+
+        long sum = 0L;
+        long t = 1L;
+        for (int i = 0; i < N; i++) {
+            sum = Math.max(sum + (long)sequence[i] * t, sequence[i] * t);
+            answer = Math.max(answer, sum);
+            t = -t;
+        }
+
+        sum = 0L;
+        t = -1L;
+        for (int i = 0; i < N; i++) {
+            sum = Math.max(sum + (long)sequence[i] * t, sequence[i] * t);
+            answer = Math.max(answer, sum);
+            t = -t;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 알고리즘 분류
dp, prefix sum

## 풀이 방법
1. [1, -1, 1, -1, ...]을 각각 곱한 수열의 연속합의 최대를 구한다.
2. [-1, 1, -1, 1, ...]을 각각 곱한 수열의 연속합의 최대를 구한다.
3. 1, 2의 max를 리턴한다.

## 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/161988
